### PR TITLE
fix: corregir nombres de variables de entorno en docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${DB_NAME}
-      API_DB_PASSWORD: ${API_DB_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db/init:/docker-entrypoint-initdb.d
@@ -43,8 +42,8 @@ services:
       DB_HOST: db
       DB_PORT: 5432
       DB_NAME: ${DB_NAME}
-      DB_USER: ${API_DB_USER}
-      DB_PASSWORD: ${API_DB_PASSWORD}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
       GIN_MODE: release
     ports:
       - "127.0.0.1:8080:8080"


### PR DESCRIPTION
  DB_USER y DB_PASSWORD son los nombres correctos definidos en .env.prod.
  API_DB_USER y API_DB_PASSWORD no existían, causando que la API
  cayera al fallback 'prueba' y fallara la autenticación en PostgreSQL.

## Descripción

<!-- Explica qué resuelve o agrega este PR. Sé específico. -->

Closes #<!-- número de issue -->

---

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad o endpoint
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `docs` — Solo documentación (Swagger, READMEs, NOTES)
- [ ] `chore` — Infraestructura / DevOps (Docker, Makefile, CI)
- [ ] `perf` — Mejora de rendimiento

---

## Breaking changes

- [ ] Este PR **no** introduce breaking changes
- [ ] Este PR **sí** introduce breaking changes → describir abajo:

<!-- Si hay breaking changes, describir qué se rompe y cómo migrar: -->

---

## Endpoints afectados

<!-- Lista los endpoints que cambian, se agregan o se eliminan. -->

| Método | Ruta | Cambio |
|--------|------|--------|
| GET | `/movilidad/...` | |

---

## Ejemplo de prueba

<!-- Pega al menos un curl que demuestre el comportamiento nuevo o corregido. -->

```bash
curl "http://localhost:8080/movilidad/..."
```

Respuesta esperada:
```json
{

}
```

---

## Checklist

- [ ] El código compila sin errores (`make build`)
- [ ] Probé el entorno DEV con `make docker-dev`
- [ ] Verifiqué los endpoints afectados manualmente
- [ ] Si modifiqué `routes/` o `models/`, corrí `make docs` y Swagger UI carga sin errores
- [ ] No incluyo archivos `.env`, contraseñas ni datos de producción
- [ ] No edité archivos en `cmd/docs/` ni `docs/` manualmente
- [ ] El PR apunta a la rama `DEV`, no directamente a `main`
