### PR TITLE
fix: eliminar environment block redundante en api service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
     networks:
       - apimetro_net_prod
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d db_apimetro"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -38,13 +38,6 @@ services:
     container_name: apimetro_api_prod
     restart: always
     env_file: .env.prod
-    environment:
-      DB_HOST: db
-      DB_PORT: 5432
-      DB_NAME: ${DB_NAME}
-      DB_USER: ${DB_USER}
-      DB_PASSWORD: ${DB_PASSWORD}
-      GIN_MODE: release
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:


### PR DESCRIPTION
  El bloque environment con sintaxis ${VAR} se resuelve desde el shell
  del servidor (donde las vars no existen), sobreescribiendo con strings
  vacíos las variables correctas que venían del env_file. La solución es
  depender exclusivamente de env_file: .env.prod para inyectar vars al
  contenedor. También se simplifica el healthcheck de db para evitar el
  mismo problema de interpolación.

## Descripción

<!-- Explica qué resuelve o agrega este PR. Sé específico. -->

Closes #<!-- número de issue -->

---

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad o endpoint
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `docs` — Solo documentación (Swagger, READMEs, NOTES)
- [ ] `chore` — Infraestructura / DevOps (Docker, Makefile, CI)
- [ ] `perf` — Mejora de rendimiento

---

## Breaking changes

- [ ] Este PR **no** introduce breaking changes
- [ ] Este PR **sí** introduce breaking changes → describir abajo:

<!-- Si hay breaking changes, describir qué se rompe y cómo migrar: -->

---

## Endpoints afectados

<!-- Lista los endpoints que cambian, se agregan o se eliminan. -->

| Método | Ruta | Cambio |
|--------|------|--------|
| GET | `/movilidad/...` | |

---

## Ejemplo de prueba

<!-- Pega al menos un curl que demuestre el comportamiento nuevo o corregido. -->

```bash
curl "http://localhost:8080/movilidad/..."
```

Respuesta esperada:
```json
{

}
```

---

## Checklist

- [ ] El código compila sin errores (`make build`)
- [ ] Probé el entorno DEV con `make docker-dev`
- [ ] Verifiqué los endpoints afectados manualmente
- [ ] Si modifiqué `routes/` o `models/`, corrí `make docs` y Swagger UI carga sin errores
- [ ] No incluyo archivos `.env`, contraseñas ni datos de producción
- [ ] No edité archivos en `cmd/docs/` ni `docs/` manualmente
- [ ] El PR apunta a la rama `DEV`, no directamente a `main`
