### PR TITLE
fix: codificar contraseña correctamente en DSN y limpiar docker-compose

### DIFF
--- a/cmd/pkg/controller/Controller.go
+++ b/cmd/pkg/controller/Controller.go
@@ -4,6 +4,7 @@ import (
 	models "Apimetro/cmd/pkg/models"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 
 	"gorm.io/driver/postgres"
@@ -49,16 +50,23 @@ func ConnectDataBase() {
 }
 
 // buildDSN construye el Data Source Name para GORM.
+// Usa url.URL para codificar correctamente caracteres especiales en la contraseña.
 func buildDSN() string {
-	if url := os.Getenv("DATABASE_URL"); url != "" {
-		return url
+	if dbURL := os.Getenv("DATABASE_URL"); dbURL != "" {
+		return dbURL
 	}
 	host := getEnv("DB_HOST", "localhost")
 	port := getEnv("DB_PORT", "5432")
 	user := getEnv("DB_USER", "prueba")
 	pass := getEnv("DB_PASSWORD", "postgres")
 	name := getEnv("DB_NAME", "db_apimetro")
-	return fmt.Sprintf("postgresql://%s:%s@%s:%s/%s", user, pass, host, port, name)
+	u := &url.URL{
+		Scheme: "postgresql",
+		User:   url.UserPassword(user, pass),
+		Host:   fmt.Sprintf("%s:%s", host, port),
+		Path:   name,
+	}
+	return u.String()
 }
 
 // getEnv retorna el valor de la variable de entorno o el fallback si está vacía.


### PR DESCRIPTION
  - Controller.go: buildDSN usa url.URL para codificar caracteres especiales (/, +, =) en la contraseña, evitando que url.Parse los interprete como delimitadores de URL
  - docker-compose.prod.yml: eliminado bloque environment redundante en api, que sobreescribía con strings vacíos las vars del env_file; healthcheck de db con valores literales para evitar el mismo problema de interpolación

## Descripción

<!-- Explica qué resuelve o agrega este PR. Sé específico. -->

Closes #<!-- número de issue -->

---

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad o endpoint
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `docs` — Solo documentación (Swagger, READMEs, NOTES)
- [ ] `chore` — Infraestructura / DevOps (Docker, Makefile, CI)
- [ ] `perf` — Mejora de rendimiento

---

## Breaking changes

- [ ] Este PR **no** introduce breaking changes
- [ ] Este PR **sí** introduce breaking changes → describir abajo:

<!-- Si hay breaking changes, describir qué se rompe y cómo migrar: -->

---

## Endpoints afectados

<!-- Lista los endpoints que cambian, se agregan o se eliminan. -->

| Método | Ruta | Cambio |
|--------|------|--------|
| GET | `/movilidad/...` | |

---

## Ejemplo de prueba

<!-- Pega al menos un curl que demuestre el comportamiento nuevo o corregido. -->

```bash
curl "http://localhost:8080/movilidad/..."
```

Respuesta esperada:
```json
{

}
```

---

## Checklist

- [ ] El código compila sin errores (`make build`)
- [ ] Probé el entorno DEV con `make docker-dev`
- [ ] Verifiqué los endpoints afectados manualmente
- [ ] Si modifiqué `routes/` o `models/`, corrí `make docs` y Swagger UI carga sin errores
- [ ] No incluyo archivos `.env`, contraseñas ni datos de producción
- [ ] No edité archivos en `cmd/docs/` ni `docs/` manualmente
- [ ] El PR apunta a la rama `DEV`, no directamente a `main`
