### PR TITLE
fix: corregir conexión a BD y permisos en producción

### DIFF
--- a/cmd/pkg/controller/transporte/Transporte.go
+++ b/cmd/pkg/controller/transporte/Transporte.go
@@ -2,23 +2,18 @@ package transporte
 
 import (
 	con "Apimetro/cmd/pkg/controller"
-	models "Apimetro/cmd/pkg/models"
 	"log"
+	"os"
 )
 
-// Inicializa el módulo de Transporte, conectando a la base de datos y migrando las tablas correspondientes.
+// Inicializa el módulo de Transporte conectando a la base de datos.
+// AutoMigrate solo corre en entorno local (DB_HOST vacío o localhost).
+// En producción el esquema es gestionado por db/init/init.sql.
 func init() {
 	log.Println("Inicializando BD y módulo de Transporte")
 	con.ConnectDataBase()
 
-	err := con.DB.AutoMigrate(
-		&models.Linea{},
-		&models.Estacion{},
-		&models.DescripcionLinea{},
-		//&models.Ramal{},
-	)
-	if err != nil {
-		log.Println("Error en la migración del módulo Metro", err)
+	if os.Getenv("DB_HOST") != "" && os.Getenv("DB_HOST") != "localhost" {
+		log.Println("Saltando AutoMigrate en módulo Transporte (entorno Docker)")
 	}
-
 }


### PR DESCRIPTION
  - Controller.go: buildDSN usa url.URL para codificar caracteres especiales en contraseña (/, +, =) que rompían url.Parse de Go
  - Transporte.go: eliminar AutoMigrate incondicional — apimetro_read no tiene permisos DDL; Controller.go ya cubre la migración local
  - docker-compose.prod.yml: eliminar bloque environment redundante que sobreescribía con vacíos las vars del env_file; healthcheck de db con valores literales

## Descripción

<!-- Explica qué resuelve o agrega este PR. Sé específico. -->

Closes #<!-- número de issue -->

---

## Tipo de cambio

- [ ] `feat` — Nueva funcionalidad o endpoint
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `docs` — Solo documentación (Swagger, READMEs, NOTES)
- [ ] `chore` — Infraestructura / DevOps (Docker, Makefile, CI)
- [ ] `perf` — Mejora de rendimiento

---

## Breaking changes

- [ ] Este PR **no** introduce breaking changes
- [ ] Este PR **sí** introduce breaking changes → describir abajo:

<!-- Si hay breaking changes, describir qué se rompe y cómo migrar: -->

---

## Endpoints afectados

<!-- Lista los endpoints que cambian, se agregan o se eliminan. -->

| Método | Ruta | Cambio |
|--------|------|--------|
| GET | `/movilidad/...` | |

---

## Ejemplo de prueba

<!-- Pega al menos un curl que demuestre el comportamiento nuevo o corregido. -->

```bash
curl "http://localhost:8080/movilidad/..."
```

Respuesta esperada:
```json
{

}
```

---

## Checklist

- [ ] El código compila sin errores (`make build`)
- [ ] Probé el entorno DEV con `make docker-dev`
- [ ] Verifiqué los endpoints afectados manualmente
- [ ] Si modifiqué `routes/` o `models/`, corrí `make docs` y Swagger UI carga sin errores
- [ ] No incluyo archivos `.env`, contraseñas ni datos de producción
- [ ] No edité archivos en `cmd/docs/` ni `docs/` manualmente
- [ ] El PR apunta a la rama `DEV`, no directamente a `main`
