### PR TITLE
ci: extender configuración de Dependabot para todos los ecosistemas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+updates:
+  # Go modules — runtime principal, expuesto a internet
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "DEV"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "gorm.io/gorm"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "gorm.io/driver/postgres"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 3
+
+  # Python (ETL) — scripts offline contra la DB
+  - package-ecosystem: "pip"
+    directory: "/ETL"
+    schedule:
+      interval: "monthly"
+    target-branch: "DEV"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 3
+
+  # Docker — imagenes base (postgis/postgis, golang, node)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "DEV"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 2
+
+  # npm (frontend) — visor interactivo MapLibre
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    target-branch: "DEV"
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 3
+
+  # GitHub Actions — CI/CD workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "DEV"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary
- Agregar monitoreo de dependencias para pip (ETL), Docker, npm (frontend) y GitHub Actions
- Agrupar PRs minor/patch de Go y npm en un solo PR para reducir ruido
- Apuntar todos los PRs de Dependabot a DEV (no a main)
- Labels automáticos para triaje
- Limitar PRs abiertos simultáneos por ecosistema

## Contexto
Dependabot solo monitoreaba Go modules. El proyecto tiene 4 ecosistemas adicionales sin cobertura.

## Test Plan
- [ ] Verificar que Dependabot genera PRs contra DEV después del merge 
- [ ] Verificar que los PRs de Go se agrupan correctamente

## Summary by Sourcery

Configure Dependabot to monitor all major ecosystems in the repo and standardize how its pull requests are created and triaged.

New Features:
- Enable Dependabot for Go modules, Python (pip), Docker, npm, and GitHub Actions with tailored schedules and limits per ecosystem.

Enhancements:
- Set Dependabot to open pull requests against the DEV branch with ecosystem-specific labels and grouped minor/patch updates for Go and npm.
- Limit the number of simultaneous open Dependabot pull requests per ecosystem to reduce noise and improve triage.